### PR TITLE
Fix VS Code not detecting tests

### DIFF
--- a/.github/workflows/firmware-ci.yml
+++ b/.github/workflows/firmware-ci.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Clone Repo
         uses: actions/checkout@v2
       - name: Install Arduino CLI
-        uses: arduino/setup-arduino-cli@v1.0.0
+        uses: arduino/setup-arduino-cli@v1.1.1
       - name: Get Python3
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/firmware-ci.yml
+++ b/.github/workflows/firmware-ci.yml
@@ -54,4 +54,4 @@ jobs:
       - name: Build unit tests
         run: cmake --build ${build_dir} -- -j$(nproc)
       - name: Run unit tests
-        run: cd ${build_dir}/test && ctest
+        run: cd ${build_dir} && ctest

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 cmake-build-debug
 build
 .idea
+.vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,3 +30,4 @@ set(calculator_dir ${CMAKE_CURRENT_SOURCE_DIR}/sketches/calculator)
 set(magiccar_dir ${CMAKE_CURRENT_SOURCE_DIR}/sketches/MagicCarControllerTestable)
 
 add_subdirectory(test)
+enable_testing()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -44,8 +44,6 @@ function(configure_test testExecutable)
     add_test(${testName} ${testExecutable} ${GTEST_RUN_FLAGS})
 endfunction(configure_test)
 
-enable_testing()
-
 # ========= Unit test configurations =========
 set(unit_tests ${CMAKE_CURRENT_SOURCE_DIR}/ut)
 set(mocks ${CMAKE_CURRENT_SOURCE_DIR}/mocks)


### PR DESCRIPTION
Move the `enable_testing()` declaration to the root `CMakeLists.txt`
so that VS Code can pick it up.