### PR TITLE
Unit tests and CI on MSVC/Windows

### DIFF
--- a/.github/workflows/firmware-ci.yml
+++ b/.github/workflows/firmware-ci.yml
@@ -28,30 +28,60 @@ jobs:
           arduino-cli compile -b esp32:esp32:esp32doit-devkit-v1 sketches/MagicCarControllerTestable/MagicCarControllerTestable.ino
 
   run-unit-tests:
-    runs-on: ubuntu-18.04
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        compiler:
-          - cc: gcc-9
-            cxx: g++-9
-          - cc: clang-9
-            cxx: clang++-9
+        os: [ubuntu-18.04, windows-latest]
+        compiler: [gnu, clang, msvc]
+
+        exclude:
+        - os: ubuntu-18.04
+          compiler: msvc
+
+        - os: windows-latest
+          compiler: gnu
+        
+        - os: windows-latest
+          compiler: clang
+
+        include:
+        - os: ubuntu-18.04
+          nproc: "-j$(nproc)"
+
+        - compiler: gnu
+          cc: gcc-9
+          cxx: g++-9
+
+        - compiler: clang
+          cc: clang-9
+          cxx: clang++-9
+
+        - compiler: msvc
+          cc: cl
+          cxx: cl
+
+
     env:
-      CC: ${{ matrix.compiler.cc }}
-      CXX: ${{ matrix.compiler.cxx }}
+      CC: ${{ matrix.cc }}
+      CXX: ${{ matrix.cxx }}
       build_dir: build
 
     steps:
       - uses: actions/checkout@v2
       - name: Get dependencies
+        if: runner.os == 'Linux'
         run: |
-          sudo apt-get install -y ${{ matrix.compiler.cc }}
-          sudo apt-get install -y ${{ matrix.compiler.cxx }}
+          sudo apt-get install -y ${{ matrix.cc }}
+          sudo apt-get install -y ${{ matrix.cxx }}
       - name: Create unit test build directory
-        run: mkdir -p ${build_dir}
+        if: runner.os == 'Linux'
+        run: mkdir -p ${{ env.build_dir }}
+      - name: Create unit test build directory
+        if: runner.os == 'Windows'
+        run: mkdir -Force ${{ env.build_dir }}
       - name: Configure unit tests
-        run: cd ${build_dir} && cmake ..
+        run: cd ${{ env.build_dir }} && cmake ..
       - name: Build unit tests
-        run: cmake --build ${build_dir} -- -j$(nproc)
+        run: cmake --build ${{ env.build_dir }} -- ${{ matrix.nproc }}
       - name: Run unit tests
-        run: cd ${build_dir} && ctest
+        run: cd ${{ env.build_dir }} && ctest

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ cmake-build-debug
 build
 .idea
 .vscode
+.vs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,28 +3,35 @@ project(reusable_and_testable_code_for_arduino)
 
 set(CMAKE_CXX_STANDARD 14)
 
-add_compile_options(
-        -Wcast-align
-        -Wpedantic
-        -Wcast-qual
-        -Wconversion
-        -Wctor-dtor-privacy
-        -Wnon-virtual-dtor
-        -Wmissing-include-dirs
-        -Wdisabled-optimization
-        -Winit-self
-        -Wnon-virtual-dtor
-        -Wold-style-cast
-        -Woverloaded-virtual
-        -Wparentheses
-        -Wredundant-decls
-        -Wshadow
-        -Wsign-promo
-        -Wstrict-aliasing
-        -Wall
-        -Wextra
-        -Werror
-)
+if(NOT MSVC)
+        add_compile_options(
+                -Wcast-align
+                -Wpedantic
+                -Wcast-qual
+                -Wconversion
+                -Wctor-dtor-privacy
+                -Wnon-virtual-dtor
+                -Wmissing-include-dirs
+                -Wdisabled-optimization
+                -Winit-self
+                -Wnon-virtual-dtor
+                -Wold-style-cast
+                -Woverloaded-virtual
+                -Wparentheses
+                -Wredundant-decls
+                -Wshadow
+                -Wsign-promo
+                -Wstrict-aliasing
+                -Wall
+                -Wextra
+                -Werror
+        )
+else()
+        add_compile_options(
+                /W4
+                /WX
+        )
+endif()
 
 set(calculator_dir ${CMAKE_CURRENT_SOURCE_DIR}/sketches/calculator)
 set(magiccar_dir ${CMAKE_CURRENT_SOURCE_DIR}/sketches/MagicCarControllerTestable)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,5 +29,5 @@ add_compile_options(
 set(calculator_dir ${CMAKE_CURRENT_SOURCE_DIR}/sketches/calculator)
 set(magiccar_dir ${CMAKE_CURRENT_SOURCE_DIR}/sketches/MagicCarControllerTestable)
 
-add_subdirectory(test)
 enable_testing()
+add_subdirectory(test)

--- a/sketches/MagicCarControllerTestable/MagicCarController.cpp
+++ b/sketches/MagicCarControllerTestable/MagicCarController.cpp
@@ -62,7 +62,11 @@ void MagicCarController::registerGyroscopeEndpoint()
 {
     mRestServer.on("/gyro", [this]() {
         char heading[4];
+        #if defined(_MSC_VER)
+        sprintf_s(heading, "%d", mCar.getHeading());
+        #else
         sprintf(heading, "%d", mCar.getHeading());
+        #endif
         mRestServer.send(kSuccess, kPlainText, heading);
     });
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,20 +24,24 @@ if (CMAKE_VERSION VERSION_LESS 2.8.11)
 endif ()
 
 # GTest and GMock do not play nicely with these flags, so disable them
-target_compile_options(gtest PRIVATE
-        -Wno-ctor-dtor-privacy
-        -Wno-missing-include-dirs
-        -Wno-sign-promo)
-target_compile_options(gmock PRIVATE -Wno-pedantic)
+if(NOT MSVC)
+        target_compile_options(gtest PRIVATE
+                -Wno-ctor-dtor-privacy
+                -Wno-missing-include-dirs
+                -Wno-sign-promo)
+        target_compile_options(gmock PRIVATE -Wno-pedantic)
+endif()
 
 function(configure_test testExecutable)
     # Link against gtest library
     target_link_libraries(${testExecutable} gtest gtest_main gmock_main)
-    # Disable variadic macro warnings (can be a problem when compiling with Clang)
-    target_compile_options(${testExecutable} PRIVATE -Wno-gnu-zero-variadic-macro-arguments)
-    # Compile and link with coverage
-    target_compile_options(${testExecutable} PRIVATE -O0 --coverage)
-    target_link_options(${testExecutable} PRIVATE --coverage)
+    if(NOT MSVC)
+        # Disable variadic macro warnings (can be a problem when compiling with Clang)
+        target_compile_options(${testExecutable} PRIVATE -Wno-gnu-zero-variadic-macro-arguments)
+        # Compile and link with coverage
+        target_compile_options(${testExecutable} PRIVATE -O0 --coverage)
+        target_link_options(${testExecutable} PRIVATE --coverage)
+    endif()
     # Create test name as the capitalized form of the test executable
     string(TOUPPER ${testExecutable} testName)
     # Add executable to test suite


### PR DESCRIPTION
- Unit tests use std::string instead of std::vector<char>
- Unit test can be run in Microsoft Visual Studio 2019